### PR TITLE
Use manual version management.

### DIFF
--- a/.github/bump-version-patch.yaml
+++ b/.github/bump-version-patch.yaml
@@ -1,0 +1,3 @@
+# Don't automatically bump the version. Wait for a human to trigger the workflow using the GitHub UI.
+- op: remove
+  path: /on/push

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -4,9 +4,6 @@
 
 name: Bump Version
 'on':
-  push:
-    branches:
-    - main
   workflow_dispatch: null
 env:
   COMMIT_PREFIX: 'bump-version: '

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "futurejs",
-    "version": "2.1.2",
+    "version": "2.1.3-pre",
     "description": "Promise-alternative library for doing asynchronous operations",
     "repository": "https://github.com/IronCoreLabs/futurejs",
     "author": "IronCore Labs",


### PR DESCRIPTION
This disables running `bump-version` on merge to `main`. Instead, we can bump the version by using the [GitHub UI](https://github.com/IronCoreLabs/FutureJS/actions/workflows/bump-version.yaml). This will have a side effect of creating a GitHub pre-release with the same name as the new version. I don't think that's a bad thing, but we can change that behavior.

It'd be nice to write a custom release workflow for this repo, that would be triggered by creation of the pre-release, that would build the release and upload its artifacts. Not sure of the priority on a task like that.

I also manually bumped the version to `2.1.3-pre`.